### PR TITLE
BiblePassage: Correct grammar for Psalms

### DIFF
--- a/data/bibleStructure.php
+++ b/data/bibleStructure.php
@@ -591,6 +591,7 @@ return [
     ],
     19 => [
         'name' => 'Psalms',
+        'singularName' => 'Psalm',
         'abbreviations' => ['ps', 'pss', 'psalm', 'pslm', 'psa', 'psm'],
         'chapterStructure' => [
             1 => 6,

--- a/src/BiblePassage.php
+++ b/src/BiblePassage.php
@@ -37,24 +37,22 @@ class BiblePassage
      */
     public function __toString(): string
     {
-        $string = $this->from->book()->name();
-
-        // Format "John"
+        // Format "John", "Psalms"
         if (
-            $this->to->book()->name() === $this->from->book()->name()
+            $this->to->book() == $this->from->book()
             && 1 === $this->from->chapter()
             && 1 === $this->from->verse()
             && $this->to->book()->chaptersInBook() === $this->to->chapter()
             && $this->to->book()->versesInChapter($this->to->chapter()) === $this->to->verse()
         ) {
-            return $string;
+            return $this->from->book()->name();
         }
 
-        $string .= ' '.$this->from->chapter();
+        $trailer = ' '.$this->from->chapter();
 
-        // Format "John 3"
+        // Format "John 3", "Psalm 3"
         if (
-            $this->to->book()->name() === $this->from->book()->name()
+            $this->to->book() == $this->from->book()
             && $this->to->chapter() === $this->from->chapter()
             && (
                 0 === $this->from->verse()
@@ -64,32 +62,40 @@ class BiblePassage
                 )
             )
         ) {
-            return $string;
+            return $this->from->book()->singularName() . $trailer;
         }
 
-        $string .= ':'.$this->from->verse();
+        $trailer .= ':'.$this->from->verse();
 
         // Format "John 3:16"
         if (
-            $this->to->book()->name() === $this->from->book()->name()
+            $this->to->book() == $this->from->book()
             && $this->to->chapter() === $this->from->chapter()
             && $this->to->verse() === $this->from->verse()
         ) {
-            return $string;
+            return $this->from->book()->singularName() . $trailer;
         }
 
         // Format "John 3:16-17"
         if ($this->from->chapter() === $this->to->chapter()) {
-            return $string.'-'.$this->to->verse();
+            return $this->from->book()->singularName()
+                .$trailer.'-'.$this->to->verse();
         }
 
         $toString = $this->to->chapter().':'.$this->to->verse();
 
         // Format "John 3:16 - Acts 1:1"
-        if ($this->from->book()->name() !== $this->to->book()->name()) {
-            return $string.' - '.$this->to->book()->name().' '.$toString;
+        if ($this->from->book() != $this->to->book()) {
+            return $this->from->book().$trailer.' - '.$this->to->book().' '.$toString;
         }
 
-        return $string.'-'.$toString;
+        // Format "Psalms 120-134"
+        if ($this->from->verse() === 1
+            && $this->to->book()->versesInChapter($this->to->chapter()) === $this->to->verse()
+        ) {
+            return $this->from->book().' '.$this->from->chapter().'-'.$this->to->chapter();
+        }
+
+        return $this->from->book().$trailer.'-'.$toString;
     }
 }

--- a/src/BiblePassage.php
+++ b/src/BiblePassage.php
@@ -96,6 +96,6 @@ class BiblePassage
             return $this->from->book().' '.$this->from->chapter().'-'.$this->to->chapter();
         }
 
-        return $this->from->book().$trailer.'-'.$toString;
+        return $this->from->book()->singularName().$trailer.'-'.$toString;
     }
 }

--- a/src/BiblePassageParser.php
+++ b/src/BiblePassageParser.php
@@ -26,6 +26,7 @@ class BiblePassageParser
             $book = new Book(
                 $bookNumber,
                 $bookData['name'],
+                $bookData['singularName'] ?? $bookData['name'],
                 $bookData['abbreviations'],
                 $bookData['chapterStructure']
             );

--- a/src/Book.php
+++ b/src/Book.php
@@ -10,17 +10,20 @@ class Book
 {
     protected $number;
     protected $name;
+    protected $singularName;
     protected $abbreviations;
     protected $chapterStructure;
 
     public function __construct(
         int $number,
         string $name,
+        string $singularName,
         array $abbreviations,
         array $chapterStructure
     ) {
         $this->number = $number;
         $this->name = $name;
+        $this->singularName = $singularName;
         $this->abbreviations = $abbreviations;
         $this->chapterStructure = $chapterStructure;
     }
@@ -38,6 +41,11 @@ class Book
     public function name(): string
     {
         return $this->name;
+    }
+
+    public function singularName(): string
+    {
+        return $this->singularName;
     }
 
     public function abbreviations(): array

--- a/tests/PassageTest.php
+++ b/tests/PassageTest.php
@@ -101,6 +101,11 @@ class PassageTest extends TestCase
                 ['Psalms', 150, 6],
                 'Psalms'
             ],
+            'Psalm to Psalm' => [
+                ['Psalms', 117, 2],
+                ['Psalms', 118, 1],
+                'Psalm 117:2-118:1'
+            ],
         ];
     }
 

--- a/tests/PassageTest.php
+++ b/tests/PassageTest.php
@@ -19,6 +19,7 @@ class PassageTest extends TestCase
             $book = new Book(
                 $bookNumber,
                 $bookData['name'],
+                $bookData['singularName'] ?? $bookData['name'],
                 $bookData['abbreviations'],
                 $bookData['chapterStructure']
             );
@@ -68,7 +69,7 @@ class PassageTest extends TestCase
             'passage spanning different chapters' => [
                 ['Genesis', 1, 1],
                 ['Genesis', 4, 26],
-                'Genesis 1:1-4:26',
+                'Genesis 1-4',
             ],
             'passage spanning different chapters with odd verses' => [
                 ['Genesis', 1, 5],
@@ -79,6 +80,26 @@ class PassageTest extends TestCase
                 ['Genesis', 1, 1],
                 ['Exodus', 5, 2],
                 'Genesis 1:1 - Exodus 5:2',
+            ],
+            'singular Psalm' => [
+                ['Psalms', 1, 1],
+                ['Psalms', 1, 6],
+                'Psalm 1'
+            ],
+            'verses in a single Psalm' => [
+                ['Psalms', 1, 2],
+                ['Psalms', 1, 3],
+                'Psalm 1:2-3'
+            ],
+            'plural Psalms' => [
+                ['Psalms', 120, 1],
+                ['Psalms', 134, 3],
+                'Psalms 120-134'
+            ],
+            'All of Psalms' => [
+                ['Psalms', 1, 1],
+                ['Psalms', 150, 6],
+                'Psalms'
             ],
         ];
     }


### PR DESCRIPTION


> The book is referred to as “Psalms” (plural), but individual psalms are referred to in the singular, as in “Please open your Bibles to Psalm 145,” and “I am going to read a psalm this morning.”

https://www.gotquestions.org/what-is-a-psalm.html

This also implements multiple whole-chapters, changing the expected value of an existing test.

> The Songs of Ascent are a special group of psalms comprising Psalms 120—134

https://www.gotquestions.org/Songs-of-Ascent.html

(For grammar's sake, the dash there is pronounced "through")

With `Psalm 117:2-118:1`, the dash would be pronounced "to", as we're going from one verse in a specific psalm to another.