### PR TITLE
Format numbered books correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 vendor/
+.idea
+.vscode
 
 *.cache
 *.swp

--- a/src/BiblePassageParser.php
+++ b/src/BiblePassageParser.php
@@ -61,7 +61,7 @@ class BiblePassageParser
             // "verse" or "verses" into "v"
             '/([^a-z])verses?([^a-z])/i' => '$1v$2',
             // add space between book number and book name
-            '/([\d])([a-zA-Z])/i' => '$1 $2',
+            '/(^|;\ *|\-)([\d])([a-zA-Z])/i' => '$1 $2 $3',
         ];
         $versesString = preg_replace(array_keys($substitutions), array_values($substitutions), $versesString);
 

--- a/src/BiblePassageParser.php
+++ b/src/BiblePassageParser.php
@@ -60,6 +60,8 @@ class BiblePassageParser
             '/([^a-z])c([^a-z])/i' => '$1ch$2',
             // "verse" or "verses" into "v"
             '/([^a-z])verses?([^a-z])/i' => '$1v$2',
+            // add space between book number and book name
+            '/([\d])([a-zA-Z])/i' => '$1 $2',
         ];
         $versesString = preg_replace(array_keys($substitutions), array_values($substitutions), $versesString);
 

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -319,6 +319,154 @@ class ParserTest extends TestCase
                     ['John 3:16b', 'John 3:17a'],
                 ],
             ],
+            'numbered book without white space between book number and book name, without chapter and verse' => [
+                '1Kings',
+                [
+                    ['1 Kings 1:1', '1 Kings 22:53'],
+                ],
+            ],
+            'numbered book without white space between book number and book name, with chapter' => [
+                '1Kings 1',
+                [
+                    ['1 Kings 1:1', '1 Kings 1:53'],
+                ],
+            ],
+            'numbered book without white space between book number and book name, with chapter and verse' => [
+                '1Kings 1:1',
+                [
+                    ['1 Kings 1:1', '1 Kings 1:1'],
+                ],
+            ],
+            'numbered book without white space between book number and book name, with chapter and verses interval' => [
+                '1Kings 1:1-2',
+                [
+                    ['1 Kings 1:1', '1 Kings 1:2'],
+                ],
+            ],
+            'numbered book without white space between book number and book name, with chapter and selected verses' => [
+                '1Kings 1:1,12',
+                [
+                    ['1 Kings 1:1', '1 Kings 1:1'],
+                    ['1 Kings 1:12', '1 Kings 1:12'],
+                ],
+            ],
+            'multiple numbered book without white space between book number and book name, without chapter and verse' => [
+                '1Kings; 2Kings',
+                [
+                    ['1 Kings 1:1', '1 Kings 22:53'],
+                    ['2 Kings 1:1', '2 Kings 25:30'],
+                ],
+            ],
+            'multiple numbered book without white space between book number and book name, with chapter' => [
+                '1Kings 1; 2Kings 1',
+                [
+                    ['1 Kings 1:1', '1 Kings 1:53'],
+                    ['2 Kings 1:1', '2 Kings 1:18'],
+                ],
+            ],
+            'multiple numbered book without white space between book number and book name, with chapter and verse' => [
+                '1Kings 1:1; 2Kings 1:1',
+                [
+                    ['1 Kings 1:1', '1 Kings 1:1'],
+                    ['2 Kings 1:1', '2 Kings 1:1'],
+                ],
+            ],
+            'multiple numbered book without white space between book number and book name, with chapter and verses interval' => [
+                '1Kings 1:1-2; 2Kings 1:1-2',
+                [
+                    ['1 Kings 1:1', '1 Kings 1:2'],
+                    ['2 Kings 1:1', '2 Kings 1:2'],
+                ],
+            ],
+            'multiple numbered book without white space between book number and book name, with chapter and selected verses' => [
+                '1Kings 1:1,12; 2Kings 1:1,12',
+                [
+                    ['1 Kings 1:1', '1 Kings 1:1'],
+                    ['1 Kings 1:12', '1 Kings 1:12'],
+                    ['2 Kings 1:1', '2 Kings 1:1'],
+                    ['2 Kings 1:12', '2 Kings 1:12'],
+                ],
+            ],
+            'multiple numbered book without white space between book number and book name, in range' => [
+                '1Kings 22:53-2Kings 1:12',
+                [
+                    ['1 Kings 22:53', '2 Kings 1:12'],
+                ],
+            ],
+            'numbered book with white space between book number and book name, without chapter and verse' => [
+                '1 Kings',
+                [
+                    ['1 Kings 1:1', '1 Kings 22:53'],
+                ],
+            ],
+            'numbered book with white space between book number and book name, with chapter' => [
+                '1 Kings 1',
+                [
+                    ['1 Kings 1:1', '1 Kings 1:53'],
+                ],
+            ],
+            'numbered book with white space between book number and book name, with chapter and verse' => [
+                '1 Kings 1:1',
+                [
+                    ['1 Kings 1:1', '1 Kings 1:1'],
+                ],
+            ],
+            'numbered book with white space between book number and book name, with chapter and verses interval' => [
+                '1 Kings 1:1-2',
+                [
+                    ['1 Kings 1:1', '1 Kings 1:2'],
+                ],
+            ],
+            'numbered book with white space between book number and book name, with chapter and selected verses' => [
+                '1 Kings 1:1,12',
+                [
+                    ['1 Kings 1:1', '1 Kings 1:1'],
+                    ['1 Kings 1:12', '1 Kings 1:12'],
+                ],
+            ],
+            'multiple numbered book with white space between book number and book name, without chapter and verse' => [
+                '1 Kings; 2 Kings',
+                [
+                    ['1 Kings 1:1', '1 Kings 22:53'],
+                    ['2 Kings 1:1', '2 Kings 25:30'],
+                ],
+            ],
+            'multiple numbered book with white space between book number and book name, with chapter' => [
+                '1 Kings 1; 2 Kings 1',
+                [
+                    ['1 Kings 1:1', '1 Kings 1:53'],
+                    ['2 Kings 1:1', '2 Kings 1:18'],
+                ],
+            ],
+            'multiple numbered book with white space between book number and book name, with chapter and verse' => [
+                '1 Kings 1:1; 2 Kings 1:1',
+                [
+                    ['1 Kings 1:1', '1 Kings 1:1'],
+                    ['2 Kings 1:1', '2 Kings 1:1'],
+                ],
+            ],
+            'multiple numbered book with white space between book number and book name, with chapter and verses interval' => [
+                '1 Kings 1:1-2; 2 Kings 1:1-2',
+                [
+                    ['1 Kings 1:1', '1 Kings 1:2'],
+                    ['2 Kings 1:1', '2 Kings 1:2'],
+                ],
+            ],
+            'multiple numbered book with white space between book number and book name, with chapter and selected verses' => [
+                '1 Kings 1:1,12; 2 Kings 1:1,12',
+                [
+                    ['1 Kings 1:1', '1 Kings 1:1'],
+                    ['1 Kings 1:12', '1 Kings 1:12'],
+                    ['2 Kings 1:1', '2 Kings 1:1'],
+                    ['2 Kings 1:12', '2 Kings 1:12'],
+                ],
+            ],
+            'multiple numbered book with white space between book number and book name, in range' => [
+                '1 Kings 22:53-2 Kings 1:12',
+                [
+                    ['1 Kings 22:53', '2 Kings 1:12'],
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
For numbered books, such as 1 Kings, add a space between the book number and the name so as not to invalidate the parsing. This is for non-English abbreviations that are written with a number and name attached.